### PR TITLE
feat: add auth middleware and update hazard report endpoints

### DIFF
--- a/accore-backend/src/controllers/citizen-auth.controller.ts
+++ b/accore-backend/src/controllers/citizen-auth.controller.ts
@@ -80,7 +80,23 @@ export const registerCitizen = async (req: Request, res: Response): Promise<void
       lastName,
     });
 
-    res.status(201).json({ message: 'Account created successfully' });
+    // Generate custom JWT so the user is authenticated automatically
+    const jwtToken = jwt.sign(
+      { id: newCitizen._id, role: 'citizen' },
+      process.env.JWT_SECRET as string,
+      { expiresIn: '7d' }
+    );
+
+    res.status(201).json({
+      message: 'Account created successfully',
+      token: jwtToken,
+      citizen: {
+        id: newCitizen._id,
+        email: newCitizen.email,
+        firstName: newCitizen.firstName,
+        lastName: newCitizen.lastName,
+      }
+    });
   } catch (error) {
     res.status(500).json({ message: 'Server error during registration' });
   }

--- a/accore-backend/src/controllers/hazard-report.controller.ts
+++ b/accore-backend/src/controllers/hazard-report.controller.ts
@@ -2,10 +2,25 @@ import { Request, Response } from 'express';
 import HazardReport from '../models/hazard-report.model';
 import { v2 as cloudinary } from 'cloudinary';
 
-export const createReport = async (req: Request, res: Response): Promise<void> => {
+// Extend the Request interface to recognize the user object attached by the middleware
+interface AuthRequest extends Request {
+  user?: {
+    id: string;
+    role: string;
+  };
+}
+
+export const createReport = async (req: AuthRequest, res: Response): Promise<void> => {
   console.log('1. Controller reached successfully. Processing image...');
 
   try {
+    const citizenId = req.user?.id;
+
+    if (!citizenId) {
+      res.status(401).json({ message: 'Unauthorized. Please log in.' });
+      return;
+    }
+
     if (!req.file) {
       console.log('Error: No image file received.');
       res.status(400).json({ message: 'Image file is required.' });
@@ -24,6 +39,7 @@ export const createReport = async (req: Request, res: Response): Promise<void> =
     const { title, description, category, severity, barangay, latitude, longitude } = req.body;
 
     const newReport = new HazardReport({
+      citizenId,
       title,
       description,
       category,
@@ -47,9 +63,16 @@ export const createReport = async (req: Request, res: Response): Promise<void> =
   }
 };
 
-export const getReports = async (req: Request, res: Response): Promise<void> => {
+export const getReports = async (req: AuthRequest, res: Response): Promise<void> => {
   try {
-    const reports = await HazardReport.find().sort({ createdAt: -1 });
+    const citizenId = req.user?.id;
+
+    if (!citizenId) {
+      res.status(401).json({ message: 'Unauthorized. Please log in.' });
+      return;
+    }
+
+    const reports = await HazardReport.find({ citizenId }).sort({ createdAt: -1 });
     res.status(200).json(reports);
   } catch (error) {
     res.status(500).json({ message: 'Failed to fetch hazard reports', error });

--- a/accore-backend/src/middlewares/auth.middleware.ts
+++ b/accore-backend/src/middlewares/auth.middleware.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+interface AuthRequest extends Request {
+  user?: any;
+}
+
+export const verifyToken = (req: AuthRequest, res: Response, next: NextFunction): void => {
+  const token = req.headers.authorization?.split(' ')[1];
+
+  if (!token) {
+    res.status(401).json({ message: 'Access denied. No token provided.' });
+    return;
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET as string);
+    req.user = decoded;
+    next();
+  } catch (error) {
+    res.status(400).json({ message: 'Invalid token.' });
+  }
+};

--- a/accore-backend/src/models/hazard-report.model.ts
+++ b/accore-backend/src/models/hazard-report.model.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Document } from 'mongoose';
 
 export interface IHazardReport extends Document {
+  citizenId: mongoose.Types.ObjectId;
   title: string;
   description: string;
   category: string;
@@ -18,6 +19,11 @@ export interface IHazardReport extends Document {
 
 const hazardReportSchema: Schema = new Schema(
   {
+    citizenId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Citizen',
+      required: true,
+    },
     title: {
       type: String,
       required: true,

--- a/accore-backend/src/routes/hazard-report.routes.ts
+++ b/accore-backend/src/routes/hazard-report.routes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import { createReport, getReports } from '../controllers/hazard-report.controller';
 import { upload } from '../middlewares/upload.middleware';
+import { verifyToken } from '../middlewares/auth.middleware';
 
 const router = express.Router();
 
-router.post('/', upload.single('image'), createReport);
-router.get('/', getReports);
+router.post('/', verifyToken, upload.single('image'), createReport);
+router.get('/', verifyToken, getReports);
 
 export default router;

--- a/accore-frontend/src/app/citizen/signup/signup.ts
+++ b/accore-frontend/src/app/citizen/signup/signup.ts
@@ -54,7 +54,7 @@ export class Signup implements OnInit {
     this.http.post('http://localhost:5000/api/auth/citizen/google', { token }).subscribe({
       next: (response: any) => {
         localStorage.setItem('token', response.token);
-        this.router.navigate(['/citizen/home']);
+        this.router.navigate(['/dashboard']);
       },
       error: (err) => {
         this.errorMessage.set('Google signup failed. Please try again.');
@@ -75,9 +75,11 @@ export class Signup implements OnInit {
     const newCitizen = this.signupForm.value;
 
     this.http.post('http://localhost:5000/api/auth/citizen/register', newCitizen).subscribe({
-      next: () => {
-        // Registration successful, navigate to login page so they can sign in
-        this.router.navigate(['/citizen/login']);
+      next: (response: any) => {
+        if (response.token) {
+          localStorage.setItem('token', response.token);
+        }
+        this.router.navigate(['/dashboard']);
       },
       error: (err) => {
         this.errorMessage.set(err.error?.message || 'Registration failed. Please try again.');

--- a/accore-frontend/src/app/services/hazard-report.ts
+++ b/accore-frontend/src/app/services/hazard-report.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -10,11 +10,18 @@ export class HazardReportService {
 
   constructor(private http: HttpClient) {}
 
+  private getAuthHeaders(): HttpHeaders {
+    const token = localStorage.getItem('token');
+    return new HttpHeaders({
+      'Authorization': `Bearer ${token}`
+    });
+  }
+
   submitReport(formData: FormData): Observable<any> {
-    return this.http.post(this.apiUrl, formData);
+    return this.http.post(this.apiUrl, formData, { headers: this.getAuthHeaders() });
   }
 
   getReports(): Observable<any[]> {
-    return this.http.get<any[]>(this.apiUrl);
+    return this.http.get<any[]>(this.apiUrl, { headers: this.getAuthHeaders() });
   }
 }


### PR DESCRIPTION
## Overview
This Pull Request introduces the new authentication middleware and connects the frontend hazard reporting service to the backend for the Angeles Fix-It project. It also ensures citizens are properly authenticated before they can submit a report.

## Key Changes
**Backend:**
* Created `auth.middleware.ts` to secure protected routes.
* Updated `citizen-auth.controller.ts` to handle citizen authentication and dashboard redirects.
* Modified `hazard-report.model.ts`, `hazard-report.controller.ts`, and `hazard-report.routes.ts` to process incoming reports from authenticated users.

**Frontend:**
* Updated the citizen `signup.ts` component to align with the new authentication flow.
* Modified the `hazard-report.ts` service to communicate with the updated backend endpoints.