### PR TITLE
feat: implement simplified flow mapping and geofencing for hazard rep…

### DIFF
--- a/accore-backend/src/controllers/barangay.controller.ts
+++ b/accore-backend/src/controllers/barangay.controller.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from 'express';
+import Barangay from '../models/barangay.model';
+
+export const getNearestBarangay = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { longitude, latitude } = req.query;
+
+    if (!longitude || !latitude) {
+      res.status(400).json({ message: 'Longitude and latitude are required.' });
+      return;
+    }
+
+    const nearestBarangay = await Barangay.findOne({
+      location: {
+        $near: {
+          $geometry: {
+            type: 'Point',
+            coordinates: [parseFloat(longitude as string), parseFloat(latitude as string)]
+          },
+          // Limit the search to 3000 meters (3 kilometers)
+          $maxDistance: 3000 
+        }
+      }
+    });
+
+    if (!nearestBarangay) {
+      // This now triggers if the user is outside Angeles City
+      res.status(404).json({ message: 'Location is outside the Angeles City service area.' });
+      return;
+    }
+
+    res.status(200).json({ data: nearestBarangay });
+  } catch (error) {
+    res.status(500).json({ message: 'Error calculating nearest location', error });
+  }
+};

--- a/accore-backend/src/models/barangay.model.ts
+++ b/accore-backend/src/models/barangay.model.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IBarangay extends Document {
+  name: string;
+  location: {
+    type: string;
+    coordinates: number[];
+  };
+}
+
+const BarangaySchema: Schema = new Schema({
+  name: { type: String, required: true },
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'], 
+      required: true
+    },
+    coordinates: {
+      type: [Number],
+      required: true
+    }
+  }
+});
+
+BarangaySchema.index({ location: '2dsphere' });
+
+export default mongoose.model<IBarangay>('Barangay', BarangaySchema);

--- a/accore-backend/src/routes/barangay.routes.ts
+++ b/accore-backend/src/routes/barangay.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { getNearestBarangay } from '../controllers/barangay.controller';
+import { verifyToken } from '../middlewares/auth.middleware';
+
+const router = Router();
+
+// We use verifyToken to ensure only authenticated users can access the route.
+router.get('/nearest-barangay', verifyToken, getNearestBarangay);
+
+export default router;

--- a/accore-backend/src/server.ts
+++ b/accore-backend/src/server.ts
@@ -7,6 +7,7 @@ import hazardReportRoutes from './routes/hazard-report.routes';
 import uploadRoutes from './routes/upload.routes';
 import authRoutes from './routes/auth.routes';
 import citizenAuthRoutes from './routes/citizen-auth.routes';
+import barangayRoutes from './routes/barangay.routes';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -25,6 +26,8 @@ app.use('/api/reports', hazardReportRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/auth/citizen', citizenAuthRoutes);
+console.log('SUCCESS: The server is reading the new barangay routes!');
+app.use('/api/geospatial', barangayRoutes);
 
 // Industry standard global error handler
 app.use((err: any, req: Request, res: Response, next: NextFunction) => {

--- a/accore-frontend/src/app/citizen/report/report.ts
+++ b/accore-frontend/src/app/citizen/report/report.ts
@@ -13,6 +13,7 @@ import { HlmTextareaImports } from '@spartan-ng/helm/textarea';
 import { HlmSpinnerImports } from '@spartan-ng/helm/spinner';
 
 import { HazardReportService } from '../../services/hazard-report';
+import { BarangayService } from '../../services/barangay'; 
 import * as L from 'leaflet';
 
 @Component({
@@ -28,40 +29,67 @@ import * as L from 'leaflet';
     BrnSelectImports,
     HlmSelectImports,
     HlmTextareaImports,
-    HlmSpinnerImports
+    HlmSpinnerImports,
   ],
   templateUrl: './report.html',
 })
 export class Report implements OnInit, OnDestroy {
   private fb = inject(FormBuilder);
   private hazardReportService = inject(HazardReportService);
+  private barangayService = inject(BarangayService); 
 
   private map: L.Map | undefined;
   private marker: L.Marker | undefined;
 
   readonly barangays = [
-    'Agapito del Rosario', 'Amsic', 'Anunas', 'Balibago', 'Capaya', 
-    'Claro M. Recto', 'Cuayan', 'Cutcut', 'Cutud', 'Lourdes North West', 
-    'Lourdes Sur', 'Lourdes Sur East', 'Malabañas', 'Margot', 'Mining', 
-    'Ninoy Aquino', 'Pampang', 'Pandan', 'Pulung Cacutud', 'Pulung Maragul', 
-    'Pulungbulu', 'Salapungan', 'San Jose', 'San Nicolas', 'Santa Teresita', 
-    'Santa Trinidad', 'Santo Cristo', 'Santo Domingo', 'Santo Rosario', 
-    'Sapalibutad', 'Sapangbato', 'Tabun', 'Virgen Delos Remedios'
+    'Agapito del Rosario',
+    'Amsic',
+    'Anunas',
+    'Balibago',
+    'Capaya',
+    'Claro M. Recto',
+    'Cuayan',
+    'Cutcut',
+    'Cutud',
+    'Lourdes North West',
+    'Lourdes Sur',
+    'Lourdes Sur East',
+    'Malabañas',
+    'Margot',
+    'Mining',
+    'Ninoy Aquino',
+    'Pampang',
+    'Pandan',
+    'Pulung Cacutud',
+    'Pulung Maragul',
+    'Pulungbulu',
+    'Salapungan',
+    'San Jose',
+    'San Nicolas',
+    'Santa Teresita',
+    'Santa Trinidad',
+    'Santo Cristo',
+    'Santo Domingo',
+    'Santo Rosario',
+    'Sapalibutad',
+    'Sapangbato',
+    'Tabun',
+    'Virgen Delos Remedios',
   ];
 
   reportForm: FormGroup = this.fb.group({
     title: ['', [Validators.required, Validators.maxLength(100)]],
     category: ['', Validators.required],
     severity: ['', Validators.required],
-    barangay: ['', Validators.required],
+    // The field is locked so users cannot manually select the wrong location
+    barangay: [{ value: '', disabled: true }, Validators.required],
     description: ['', Validators.required],
     latitude: [15.145],
     longitude: [120.5887],
   });
 
   selectedFile: File | null = null;
-  
-  // Converted state to Signals for Zoneless Angular
+
   isSubmitting = signal(false);
   isCompressing = signal(false);
   statusMessage = signal('');
@@ -149,37 +177,57 @@ export class Report implements OnInit, OnDestroy {
       latitude: lat,
       longitude: lng,
     });
+
+    this.barangayService.getNearestBarangay(lng, lat).subscribe({
+      next: (response) => {
+        if (response && response.data && response.data.name) {
+          this.reportForm.patchValue({
+            barangay: response.data.name,
+          });
+          this.statusMessage.set('');
+          this.isError.set(false);
+        }
+      },
+      error: (error) => {
+        this.reportForm.patchValue({
+          barangay: '',
+        });
+
+        this.statusMessage.set(
+          'The selected location is outside Angeles City. Please move the pin.',
+        );
+        this.isError.set(true);
+      },
+    });
   }
 
   async onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
       const originalFile = input.files[0];
-      
+
       const options = {
         maxSizeMB: 0.5,
         maxWidthOrHeight: 1280,
-        useWebWorker: true 
+        useWebWorker: true,
       };
 
       try {
-        // Trigger UI update using Signals
         this.isCompressing.set(true);
         this.statusMessage.set('Optimizing image...');
 
         const compressedBlob = await imageCompression(originalFile, options);
-        
+
         this.selectedFile = new File([compressedBlob], originalFile.name, {
           type: compressedBlob.type,
           lastModified: Date.now(),
         });
 
-        // Trigger UI update to clear loading state
         this.isCompressing.set(false);
         this.statusMessage.set('');
       } catch (error) {
         console.error('Error compressing image:', error);
-        this.selectedFile = originalFile; 
+        this.selectedFile = originalFile;
         this.isCompressing.set(false);
         this.statusMessage.set('');
       }
@@ -187,6 +235,15 @@ export class Report implements OnInit, OnDestroy {
   }
 
   onSubmit() {
+    // We retrieve the form values first to check the disabled barangay field
+    const formValues = this.reportForm.getRawValue();
+
+    if (!formValues.barangay) {
+      this.statusMessage.set('You cannot submit a report outside Angeles City.');
+      this.isError.set(true);
+      return;
+    }
+
     if (this.reportForm.invalid || !this.selectedFile) {
       this.statusMessage.set('Please fill all required fields and select an image.');
       this.isError.set(true);
@@ -199,13 +256,13 @@ export class Report implements OnInit, OnDestroy {
 
     const formData = new FormData();
     formData.append('image', this.selectedFile);
-    formData.append('title', this.reportForm.get('title')?.value);
-    formData.append('category', this.reportForm.get('category')?.value);
-    formData.append('severity', this.reportForm.get('severity')?.value);
-    formData.append('barangay', this.reportForm.get('barangay')?.value);
-    formData.append('description', this.reportForm.get('description')?.value);
-    formData.append('latitude', this.reportForm.get('latitude')?.value);
-    formData.append('longitude', this.reportForm.get('longitude')?.value);
+    formData.append('title', formValues.title);
+    formData.append('category', formValues.category);
+    formData.append('severity', formValues.severity);
+    formData.append('barangay', formValues.barangay);
+    formData.append('description', formValues.description);
+    formData.append('latitude', formValues.latitude);
+    formData.append('longitude', formValues.longitude);
 
     this.hazardReportService.submitReport(formData).subscribe({
       next: () => {

--- a/accore-frontend/src/app/services/barangay.spec.ts
+++ b/accore-frontend/src/app/services/barangay.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Barangay } from './barangay';
+
+describe('Barangay', () => {
+  let service: Barangay;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Barangay);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/accore-frontend/src/app/services/barangay.ts
+++ b/accore-frontend/src/app/services/barangay.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BarangayService { 
+  // Update this URL if you changed the route path in your server.ts
+  private apiUrl = 'http://localhost:5000/api/geospatial/nearest-barangay';
+
+  constructor(private http: HttpClient) {}
+
+  private getAuthHeaders(): HttpHeaders {
+    const token = localStorage.getItem('adminToken') || localStorage.getItem('token');
+    return new HttpHeaders({
+      'Authorization': `Bearer ${token}`
+    });
+  }
+
+  getNearestBarangay(longitude: number, latitude: number): Observable<any> {
+    // HttpParams safely encodes the coordinates into the URL query string
+    const params = new HttpParams()
+      .set('longitude', longitude.toString())
+      .set('latitude', latitude.toString());
+
+    return this.http.get<any>(this.apiUrl, { 
+      headers: this.getAuthHeaders(),
+      params: params 
+    });
+  }
+}


### PR DESCRIPTION
This PR implements a simplified geospatial flow mapping system to automatically identify the nearest vulnerable area (barangay) when a water hazard is reported. It also introduces geofencing to ensure reports are only submitted within the Angeles City service area.

**Backend**

1. Model: Created BarangaySchema with a 2dsphere index for high-performance geospatial queries.
2. Controller: Implemented getNearestBarangay using MongoDB's $near operator with a 3000m $maxDistance limit to enforce city boundaries.
3. Routes: Added a specialized /api/geospatial route protected by JWT authentication.

**Frontend**

1. Service: Created BarangayService to handle HTTP communication with the new geospatial endpoint.
2. Component: Updated the Report component to:
3. Automatically fetch and set the barangay based on the Leaflet map pin location.
4. Lock the barangay dropdown to ensure the "Single Source of Truth" from the map.
5. Implement error handling to block submissions and warn users when a pin is dropped outside Angeles City.
