### PR TITLE
fix(dashboard): resolve missing map pins and implement severity color-coding

### DIFF
--- a/accore-backend/src/controllers/hazard-report.controller.ts
+++ b/accore-backend/src/controllers/hazard-report.controller.ts
@@ -204,22 +204,12 @@ export const getAnalytics = async (
     const analyticsData = await HazardReport.aggregate([
       {
         $facet: {
-          totalActive: [
-            {
-              $match: {
-                status: { $in: ["Reported", "Under Review", "In Progress"] },
-              },
-            },
-            { $count: "count" },
-          ],
           byStatus: [{ $group: { _id: "$status", count: { $sum: 1 } } }],
           byBarangay: [
             { $group: { _id: "$barangay", count: { $sum: 1 } } },
             { $sort: { count: -1 } },
           ],
-          // NEW: Group by Severity for the Doughnut Chart
           bySeverity: [{ $group: { _id: "$severity", count: { $sum: 1 } } }],
-          // NEW: Get the 5 most recent reports for the Activity Feed
           recentActivity: [
             { $sort: { createdAt: -1 } },
             { $limit: 5 },
@@ -234,18 +224,28 @@ export const getAnalytics = async (
               },
             },
           ],
+          activeHotspots: [
+            { $match: { status: { $in: ["Reported", "Under Review", "In Progress"] } } },
+            { $project: { title: 1, severity: 1, location: 1 } }
+          ]
         },
       },
     ]);
 
     const [data] = analyticsData;
 
+    const activeStatuses = ["Reported", "Under Review", "In Progress"];
+    const totalActive = data?.byStatus
+      .filter((s: any) => activeStatuses.includes(s._id))
+      .reduce((sum: number, s: any) => sum + s.count, 0) || 0;
+
     const result = {
-      totalActive: data?.totalActive[0]?.count || 0,
+      totalActive,
       byStatus: data?.byStatus || [],
       byBarangay: data?.byBarangay || [],
       bySeverity: data?.bySeverity || [],
       recentActivity: data?.recentActivity || [],
+      activeHotspots: data?.activeHotspots || [],
     };
 
     res.status(200).json(result);

--- a/accore-frontend/src/app/admin/analytics-dashboard/analytics-dashboard.ts
+++ b/accore-frontend/src/app/admin/analytics-dashboard/analytics-dashboard.ts
@@ -87,7 +87,7 @@ export class AnalyticsDashboard implements OnInit, OnDestroy {
         
         this.isLoading.set(false);
         if (isPlatformBrowser(this.platformId)) {
-          setTimeout(() => this.initMiniMap(data?.recentActivity || []), 100);
+          setTimeout(() => this.initMiniMap(data?.activeHotspots || []), 100);
         }
       },
       error: (err) => {
@@ -97,25 +97,33 @@ export class AnalyticsDashboard implements OnInit, OnDestroy {
     });
   }
 
-  private initMiniMap(recentReports: any[]) {
+  private initMiniMap(hotspots: any[]) {
     if (this.map) this.map.remove();
-    this.map = L.map('mini-map', { zoomControl: false }).setView([15.145, 120.5887], 12);
+    this.map = L.map('mini-map', { zoomControl: false }).setView([15.145, 120.5887], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(this.map);
 
-    recentReports.forEach(report => {
+    hotspots.forEach(report => {
       if (report.location?.coordinates?.length >= 2) {
-        // Access array indexes to prevent leaflet rendering failures
-        const lng = report.location.coordinates;
-        const lat = report.location.coordinates;
+        const lng = report.location.coordinates[0];
+        const lat = report.location.coordinates[1];
+
+        let pinColor = '#3b82f6'; 
+        if (report.severity === 'Critical') pinColor = '#ef4444'; 
+        if (report.severity === 'Medium') pinColor = '#f59e0b'; 
         
         L.circleMarker([lat, lng], {
-          radius: 6,
-          fillColor: '#ef4444',
+          radius: 7,
+          fillColor: pinColor,
           color: '#ffffff',
           weight: 2,
           opacity: 1,
-          fillOpacity: 0.8
-        }).addTo(this.map!).bindTooltip(report.title);
+          fillOpacity: 0.9
+        }).addTo(this.map!).bindTooltip(`
+          <div style="text-align: center;">
+            <strong>${report.title}</strong><br/>
+            <span style="color: ${pinColor}; font-weight: bold;">${report.severity}</span>
+          </div>
+        `);
       }
     });
   }
@@ -124,8 +132,6 @@ export class AnalyticsDashboard implements OnInit, OnDestroy {
     if (!this.analyticsData()) return;
     const data = this.analyticsData();
     
-    // We generate the CSV blob directly here because the ExportService 
-    // expects a specific report model, not grouped analytics data.
     const csvRows = ['Category,Name,Count'];
     
     data.byBarangay.forEach((b: any) => csvRows.push(`"Barangay","${b._id}","${b.count}"`));


### PR DESCRIPTION
## Overview
This PR addresses the issue where hazard pins were not appearing on the Admin Analytics Dashboard map. It also introduces a color-coding system to help administrators visually distinguish the urgency of reported hazards at a glance.

## Key Changes
- **Map Rendering Fix**: Resolved a coordinate mapping bug in `analytics-dashboard.ts` by correctly accessing the longitude `` and latitude `` indexes within the location array.
- **Active Hotspots Implementation**: Updated the `getAnalytics` controller to specifically aggregate and return all "Active" hazards (Reported, Under Review, In Progress) for map visualization.
- **Severity Color-Coding**: Implemented dynamic pin coloring on the dashboard mini-map:
  - 🔴 **Critical**: Red
  - 🟠 **Medium**: Orange
  - 🔵 **Low**: Blue (Default)
- **Enhanced Tooltips**: Added formatted tooltips to map pins displaying both the hazard title and the severity level in its corresponding color.

## How to Test
1. Start both backend (`npm run dev`) and frontend (`ng serve`).
2. Navigate to the Admin Dashboard (`/admin/dashboard`).
3. Verify that pins are now visible on the "Recent Incident Hotspots" map.
4. Confirm that pin colors match the severity levels of the reports (Critical = Red, etc.).
5. Hover over a pin to ensure the tooltip displays correctly.

## Related Issues
Fixes the missing dashboard map pins identified during the Analytics Dashboard implementation.