### PR TITLE
feat: implement citizen hazard report verification system

### DIFF
--- a/accore-backend/src/controllers/hazard-report.controller.ts
+++ b/accore-backend/src/controllers/hazard-report.controller.ts
@@ -32,7 +32,11 @@ const ACTIVE_PUBLIC_STATUSES = [
   "In Progress",
 ];
 
-const parsePositiveInt = (value: unknown, fallback: number, max = 100): number => {
+const parsePositiveInt = (
+  value: unknown,
+  fallback: number,
+  max = 100,
+): number => {
   const parsed = Number.parseInt(String(value ?? ""), 10);
 
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -68,7 +72,10 @@ const buildAdminMatch = (query: Request["query"]) => {
   if (severity && severity !== "All") filters.severity = severity;
   if (status && status !== "All") filters.status = status;
   if (search) {
-    const searchRegex = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+    const searchRegex = new RegExp(
+      search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+      "i",
+    );
     const searchFilters: Record<string, unknown>[] = [
       { title: searchRegex },
       { category: searchRegex },
@@ -197,7 +204,8 @@ export const getReports = async (
       return;
     }
 
-    const hasPagination = req.query.page !== undefined || req.query.limit !== undefined;
+    const hasPagination =
+      req.query.page !== undefined || req.query.limit !== undefined;
     const page = parsePositiveInt(req.query.page, 1);
     const limit = parsePositiveInt(req.query.limit, 10);
     const skip = (page - 1) * limit;
@@ -206,7 +214,8 @@ export const getReports = async (
       if (hasPagination) {
         const filters = buildAdminMatch(req.query);
         const sortColumn = normalizeQueryValue(req.query.sortColumn);
-        const sortDirection = normalizeQueryValue(req.query.sortDirection) === "asc" ? 1 : -1;
+        const sortDirection =
+          normalizeQueryValue(req.query.sortDirection) === "asc" ? 1 : -1;
         const pipeline: any[] = [];
         const archiveFilter = filters.isArchived;
 
@@ -218,19 +227,23 @@ export const getReports = async (
           $addFields: {
             severityWeight: {
               $switch: {
-                branches: Object.entries(SEVERITY_WEIGHT).map(([label, weight]) => ({
-                  case: { $eq: ["$severity", label] },
-                  then: weight,
-                })),
+                branches: Object.entries(SEVERITY_WEIGHT).map(
+                  ([label, weight]) => ({
+                    case: { $eq: ["$severity", label] },
+                    then: weight,
+                  }),
+                ),
                 default: 0,
               },
             },
             statusWeight: {
               $switch: {
-                branches: Object.entries(STATUS_WEIGHT).map(([label, weight]) => ({
-                  case: { $eq: ["$status", label] },
-                  then: weight,
-                })),
+                branches: Object.entries(STATUS_WEIGHT).map(
+                  ([label, weight]) => ({
+                    case: { $eq: ["$status", label] },
+                    then: weight,
+                  }),
+                ),
                 default: 0,
               },
             },
@@ -301,7 +314,10 @@ export const getReports = async (
 
       if (hasPagination) {
         const [reports, total] = await Promise.all([
-          HazardReport.find(query).sort({ createdAt: -1 }).skip(skip).limit(limit),
+          HazardReport.find(query)
+            .sort({ createdAt: -1 })
+            .skip(skip)
+            .limit(limit),
           HazardReport.countDocuments(query),
         ]);
 
@@ -375,7 +391,7 @@ export const getReportById = async (req: AuthRequest, res: Response) => {
 
     const report = await HazardReport.findById(req.params.id).populate(
       "citizenId",
-      "firstName lastName"
+      "firstName lastName",
     );
 
     if (!report) {
@@ -383,12 +399,16 @@ export const getReportById = async (req: AuthRequest, res: Response) => {
     }
 
     const ownerId =
-      typeof report.citizenId === "object" && report.citizenId !== null && "_id" in report.citizenId
+      typeof report.citizenId === "object" &&
+      report.citizenId !== null &&
+      "_id" in report.citizenId
         ? String((report.citizenId as any)._id)
         : String(report.citizenId);
 
     if (userRole !== "admin" && ownerId !== userId) {
-      return res.status(403).json({ message: "Forbidden. You can only view your own reports." });
+      return res
+        .status(403)
+        .json({ message: "Forbidden. You can only view your own reports." });
     }
 
     res.status(200).json(report);
@@ -488,9 +508,13 @@ export const getAnalytics = async (
             },
           ],
           activeHotspots: [
-            { $match: { status: { $in: ["Reported", "Under Review", "In Progress"] } } },
-            { $project: { title: 1, severity: 1, location: 1 } }
-          ]
+            {
+              $match: {
+                status: { $in: ["Reported", "Under Review", "In Progress"] },
+              },
+            },
+            { $project: { title: 1, severity: 1, location: 1 } },
+          ],
         },
       },
     ]);
@@ -498,9 +522,10 @@ export const getAnalytics = async (
     const [data] = analyticsData;
 
     const activeStatuses = ["Reported", "Under Review", "In Progress"];
-    const totalActive = data?.byStatus
-      .filter((s: any) => activeStatuses.includes(s._id))
-      .reduce((sum: number, s: any) => sum + s.count, 0) || 0;
+    const totalActive =
+      data?.byStatus
+        .filter((s: any) => activeStatuses.includes(s._id))
+        .reduce((sum: number, s: any) => sum + s.count, 0) || 0;
 
     const result = {
       totalActive,
@@ -529,14 +554,73 @@ export const getPublicReports = async (
       isArchived: { $ne: true },
       status: { $in: ACTIVE_PUBLIC_STATUSES },
     })
-      .select("title description category severity barangay location status createdAt")
+      .select(
+        "title description category severity barangay location status createdAt verifications",
+      )
       .sort({ createdAt: -1 });
-      
+
     res.status(200).json(reports);
   } catch (error: any) {
     res.status(500).json({
       message: "Failed to fetch public reports",
       error: error.message,
     });
+  }
+};
+
+export const toggleVerify = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  try {
+    const reportId = req.params.id;
+    // Check for both id and _id depending on how your JWT payload is structured
+    const userId = req.user?.id || req.user?._id;
+
+    if (!userId) {
+      res
+        .status(401)
+        .json({ message: "Unauthorized. User ID not found in token." });
+      return;
+    }
+
+    const report = await HazardReport.findById(reportId);
+
+    if (!report) {
+      res.status(404).json({ message: "Report not found" });
+      return;
+    }
+
+    // Safely initialize the array if it doesn't exist for older reports
+    if (!report.verifications) {
+      report.verifications = [];
+    }
+
+    // Clean out any null/undefined values that might have sneaked into the DB
+    report.verifications = report.verifications.filter((id) => id != null);
+
+    // Safely check if the user has already verified
+    const hasVerified = report.verifications.some(
+      (id) => id && id.toString() === userId.toString(),
+    );
+
+    if (hasVerified) {
+      // User already verified, so we remove their ID (un-verify)
+      report.verifications = report.verifications.filter(
+        (id) => id && id.toString() !== userId.toString(),
+      );
+    } else {
+      // User has not verified, so we add their ID
+      report.verifications.push(userId as any);
+    }
+
+    await report.save();
+
+    res.status(200).json(report);
+  } catch (error: any) {
+    console.error("Error toggling verification:", error);
+    res
+      .status(500)
+      .json({ message: "Internal server error", error: error.message });
   }
 };

--- a/accore-backend/src/models/hazard-report.model.ts
+++ b/accore-backend/src/models/hazard-report.model.ts
@@ -1,5 +1,5 @@
-import mongoose, { Schema, Document } from 'mongoose';
-import { ANGELES_CITY_BARANGAYS } from '../utils/constants';
+import mongoose, { Schema, Document } from "mongoose";
+import { ANGELES_CITY_BARANGAYS } from "../utils/constants";
 
 export interface IHazardReport extends Document {
   citizenId: mongoose.Types.ObjectId;
@@ -16,6 +16,7 @@ export interface IHazardReport extends Document {
   };
   status: string;
   imageURL: string;
+  verifications: mongoose.Types.ObjectId[];
   statusHistory: {
     status: string;
     updatedBy: mongoose.Types.ObjectId;
@@ -30,7 +31,7 @@ const hazardReportSchema: Schema = new Schema(
   {
     citizenId: {
       type: Schema.Types.ObjectId,
-      ref: 'Citizen',
+      ref: "Citizen",
       required: true,
     },
     title: {
@@ -45,12 +46,18 @@ const hazardReportSchema: Schema = new Schema(
     category: {
       type: String,
       required: true,
-      enum: ['Pothole', 'Clogged Drain', 'Fallen Tree', 'Streetlight Out', 'Flooding'],
+      enum: [
+        "Pothole",
+        "Clogged Drain",
+        "Fallen Tree",
+        "Streetlight Out",
+        "Flooding",
+      ],
     },
     severity: {
       type: String,
       required: true,
-      enum: ['Low', 'Medium', 'Critical'],
+      enum: ["Low", "Medium", "Critical"],
     },
     barangay: {
       type: String,
@@ -68,11 +75,11 @@ const hazardReportSchema: Schema = new Schema(
     location: {
       type: {
         type: String,
-        enum: ['Point'], 
+        enum: ["Point"],
         required: true,
       },
       coordinates: {
-        type: [Number], 
+        type: [Number],
         required: true,
       },
     },
@@ -80,27 +87,40 @@ const hazardReportSchema: Schema = new Schema(
       type: String,
       required: true,
       // Updated to match the new 4-step tracker
-      enum: ['Reported', 'Under Review', 'In Progress', 'Resolved'],
-      default: 'Reported',
+      enum: ["Reported", "Under Review", "In Progress", "Resolved"],
+      default: "Reported",
     },
     imageURL: {
       type: String,
       required: true,
     },
+    verifications: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "Citizen",
+      },
+    ],
     statusHistory: [
       {
         status: { type: String, required: true },
-        updatedBy: { type: Schema.Types.ObjectId, ref: 'Admin', required: true },
+        updatedBy: {
+          type: Schema.Types.ObjectId,
+          ref: "Admin",
+          required: true,
+        },
         adminName: { type: String, required: true },
-        updatedAt: { type: Date, default: Date.now }
-      }
-    ]
+        updatedAt: { type: Date, default: Date.now },
+      },
+    ],
   },
   {
     timestamps: true,
-  }
+  },
 );
 
-hazardReportSchema.index({ location: '2dsphere' });
+hazardReportSchema.index({ location: "2dsphere" });
 
-export default mongoose.model<IHazardReport>('HazardReport', hazardReportSchema);
+export default mongoose.model<IHazardReport>(
+  "HazardReport",
+  hazardReportSchema,
+);

--- a/accore-backend/src/routes/hazard-report.routes.ts
+++ b/accore-backend/src/routes/hazard-report.routes.ts
@@ -6,7 +6,8 @@ import {
   updateReportStatus,
   archiveReport,
   getAnalytics,
-  getPublicReports
+  getPublicReports,
+  toggleVerify // Make sure this is exported from your controller!
 } from "../controllers/hazard-report.controller";
 import { upload } from "../middlewares/upload.middleware";
 import { verifyToken, verifyAdmin } from "../middlewares/auth.middleware";
@@ -19,6 +20,10 @@ router.post("/", verifyToken, reportLimiter, upload.single("image"), createRepor
 router.get("/", verifyToken, getReports);
 router.get("/public", verifyToken, getPublicReports);
 router.get("/:id", verifyToken, getReportById);
+
+// FIX: Use verifyToken here
+router.patch("/:id/verify", verifyToken, toggleVerify);
+
 router.put("/:id/status", verifyToken, verifyAdmin, updateReportStatus);
 router.put("/:id/archive", verifyToken, verifyAdmin, archiveReport);
 

--- a/accore-frontend/src/app/citizen/dashboard/dashboard.css
+++ b/accore-frontend/src/app/citizen/dashboard/dashboard.css
@@ -1,0 +1,102 @@
+.leaflet-popup-content-wrapper {
+  border-radius: 12px;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.leaflet-popup-content {
+  margin: 0;
+  width: 240px !important;
+}
+
+.ac-core-cluster {
+  background: transparent;
+  border: 0;
+}
+
+.ac-core-cluster-shell {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.ac-core-cluster-pin {
+  align-items: center;
+  background: linear-gradient(135deg, #cf2e1d 0%, #ac1001 68%, #7f0c01 100%);
+  border: 2px solid rgba(255, 255, 255, 0.95);
+  border-radius: 50% 50% 50% 0;
+  box-shadow: 0 14px 28px rgba(127, 12, 1, 0.28);
+  display: flex;
+  justify-content: center;
+  position: relative;
+  transform: rotate(-45deg);
+  width: 100%;
+  height: 100%;
+}
+
+.ac-core-cluster-pin::before {
+  background: rgba(172, 16, 1, 0.22);
+  border-radius: 50% 50% 50% 0;
+  content: '';
+  inset: -5px;
+  position: absolute;
+  z-index: -1;
+}
+
+.ac-core-cluster-count {
+  align-items: center;
+  color: #ffffff;
+  display: flex;
+  font-weight: 800;
+  justify-content: center;
+  letter-spacing: -0.02em;
+  transform: rotate(45deg);
+}
+
+.ac-core-cluster--small {
+  height: 34px;
+  width: 34px;
+}
+
+.ac-core-cluster--small .ac-core-cluster-count {
+  font-size: 11px;
+}
+
+.ac-core-cluster--medium {
+  height: 40px;
+  width: 40px;
+}
+
+.ac-core-cluster--medium .ac-core-cluster-pin {
+  background: linear-gradient(135deg, #d83b29 0%, #b51202 65%, #870d01 100%);
+  box-shadow: 0 18px 34px rgba(127, 12, 1, 0.3);
+}
+
+.ac-core-cluster--medium .ac-core-cluster-pin::before {
+  background: rgba(172, 16, 1, 0.24);
+  inset: -6px;
+}
+
+.ac-core-cluster--medium .ac-core-cluster-count {
+  font-size: 12px;
+}
+
+.ac-core-cluster--large {
+  height: 46px;
+  width: 46px;
+}
+
+.ac-core-cluster--large .ac-core-cluster-pin {
+  background: linear-gradient(135deg, #bf1b0b 0%, #930d01 70%, #650900 100%);
+  box-shadow: 0 22px 38px rgba(96, 7, 0, 0.34);
+}
+
+.ac-core-cluster--large .ac-core-cluster-pin::before {
+  background: rgba(127, 12, 1, 0.28);
+  inset: -7px;
+}
+
+.ac-core-cluster--large .ac-core-cluster-count {
+  font-size: 14px;
+}

--- a/accore-frontend/src/app/citizen/dashboard/dashboard.ts
+++ b/accore-frontend/src/app/citizen/dashboard/dashboard.ts
@@ -14,95 +14,8 @@ import 'leaflet.markercluster';
   standalone: true,
   imports: [RouterModule, CommonModule, CitizenHeaderComponent, CitizenFooterComponent],
   templateUrl: './dashboard.html',
-  encapsulation: ViewEncapsulation.None,
-  styles: [`
-    .leaflet-popup-content-wrapper {
-      border-radius: 12px;
-      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    }
-    .leaflet-popup-content {
-      margin: 0;
-      width: 240px !important;
-    }
-    .ac-core-cluster {
-      background: transparent;
-      border: 0;
-    }
-    .ac-core-cluster-shell {
-      display: flex;
-      height: 100%;
-      justify-content: center;
-      align-items: flex-start;
-      width: 100%;
-    }
-    .ac-core-cluster-pin {
-      align-items: center;
-      background: linear-gradient(135deg, #cf2e1d 0%, #ac1001 68%, #7f0c01 100%);
-      border: 2px solid rgba(255, 255, 255, 0.95);
-      border-radius: 50% 50% 50% 0;
-      box-shadow: 0 14px 28px rgba(127, 12, 1, 0.28);
-      display: flex;
-      justify-content: center;
-      position: relative;
-      transform: rotate(-45deg);
-      width: 100%;
-      height: 100%;
-    }
-    .ac-core-cluster-pin::before {
-      background: rgba(172, 16, 1, 0.22);
-      border-radius: 50% 50% 50% 0;
-      content: '';
-      inset: -5px;
-      position: absolute;
-      z-index: -1;
-    }
-    .ac-core-cluster-count {
-      align-items: center;
-      color: #ffffff;
-      display: flex;
-      font-weight: 800;
-      justify-content: center;
-      letter-spacing: -0.02em;
-      transform: rotate(45deg);
-    }
-    .ac-core-cluster--small {
-      height: 34px;
-      width: 34px;
-    }
-    .ac-core-cluster--small .ac-core-cluster-count {
-      font-size: 11px;
-    }
-    .ac-core-cluster--medium {
-      height: 40px;
-      width: 40px;
-    }
-    .ac-core-cluster--medium .ac-core-cluster-pin {
-      background: linear-gradient(135deg, #d83b29 0%, #b51202 65%, #870d01 100%);
-      box-shadow: 0 18px 34px rgba(127, 12, 1, 0.3);
-    }
-    .ac-core-cluster--medium .ac-core-cluster-pin::before {
-      background: rgba(172, 16, 1, 0.24);
-      inset: -6px;
-    }
-    .ac-core-cluster--medium .ac-core-cluster-count {
-      font-size: 12px;
-    }
-    .ac-core-cluster--large {
-      height: 46px;
-      width: 46px;
-    }
-    .ac-core-cluster--large .ac-core-cluster-pin {
-      background: linear-gradient(135deg, #bf1b0b 0%, #930d01 70%, #650900 100%);
-      box-shadow: 0 22px 38px rgba(96, 7, 0, 0.34);
-    }
-    .ac-core-cluster--large .ac-core-cluster-pin::before {
-      background: rgba(127, 12, 1, 0.28);
-      inset: -7px;
-    }
-    .ac-core-cluster--large .ac-core-cluster-count {
-      font-size: 14px;
-    }
-  `]
+  styleUrls: ['./dashboard.css'],
+  encapsulation: ViewEncapsulation.None
 })
 export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
   private hazardReportService = inject(HazardReportService);
@@ -121,11 +34,13 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
   resolvedReports = 0;
   impactTitle = 'Civic Starter';
   firstName = 'Citizen';
+  currentUserId: string | null = null;
   cityInsights: { category: string, count: number, weeklyCount: number, percentage: number }[] = [];
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {
       this.firstName = this.authService.getFirstName() || 'Citizen';
+      this.currentUserId = this.authService.getUserId(); 
       this.fetchMyReports();
     }
   }
@@ -154,7 +69,7 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
         this.isRecentLoading = false;
         this.cdr.detectChanges();
       },
-      error: (error) => {
+      error: (error: any) => {
         console.error('Failed to fetch personal reports', error);
         this.isRecentLoading = false;
         this.cdr.detectChanges();
@@ -174,7 +89,7 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
 
         this.cdr.detectChanges();
       },
-      error: (error) => {
+      error: (error: any) => {
         console.error('Failed to load public city reports', error);
         this.isInsightsLoading = false;
         this.cdr.detectChanges();
@@ -280,6 +195,39 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
     });
 
     this.map.addLayer(this.markerClusterGroup);
+
+    this.map.on('popupopen', (e: any) => {
+      const popupNode = e.popup.getElement();
+      const verifyBtn = popupNode.querySelector('.verify-btn');
+      
+      if (verifyBtn) {
+        verifyBtn.addEventListener('click', (event: Event) => {
+          const target = event.target as HTMLElement;
+          const reportId = target.getAttribute('data-report-id');
+          if (reportId) {
+            this.handleVerifyClick(reportId, target);
+          }
+        });
+      }
+    });
+  }
+
+  handleVerifyClick(reportId: string, buttonElement: HTMLElement) {
+    buttonElement.style.opacity = '0.5';
+    buttonElement.style.pointerEvents = 'none';
+    buttonElement.innerText = 'Updating...';
+
+    this.hazardReportService.toggleVerify(reportId).subscribe({
+      next: () => {
+        this.fetchCityMapData();
+      },
+      error: (err: any) => {
+        console.error('Failed to verify report', err);
+        buttonElement.style.opacity = '1';
+        buttonElement.style.pointerEvents = 'auto';
+        buttonElement.innerText = 'Verify Issue';
+      }
+    });
   }
 
   getMarkerColor(severity: string | undefined): string {
@@ -312,6 +260,10 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
       const lng = report.location.coordinates[0];
       const lat = report.location.coordinates[1];
       const markerColor = this.getMarkerColor(report.severity);
+      
+      const verifications = report.verifications || [];
+      const verificationCount = verifications.length;
+      const hasVerified = this.currentUserId ? verifications.includes(this.currentUserId) : false;
 
       const customIcon = L.divIcon({
         className: 'bg-transparent border-0',
@@ -343,9 +295,12 @@ export class Dashboard implements OnInit, AfterViewInit, OnDestroy {
           </div>
 
           <div style="margin-top: 8px; padding-top: 12px; border-top: 1px solid #e5e5e5; display: flex; align-items: center; justify-content: space-between;">
-            <span style="font-size: 11px; color: #737373; font-weight: 600;">2 citizens verified</span>
-            <button onclick="alert('Verification feature coming soon!')" style="background-color: #171717; color: white; border: none; padding: 6px 12px; border-radius: 6px; font-size: 11px; font-weight: bold; cursor: pointer; font-family: 'Google Sans', sans-serif;">
-              Verify
+            <span style="font-size: 11px; color: #737373; font-weight: 600;">${verificationCount} citizens verified</span>
+            <button 
+              class="verify-btn" 
+              data-report-id="${report._id}"
+              style="background-color: ${hasVerified ? '#16a34a' : '#171717'}; color: white; border: none; padding: 6px 12px; border-radius: 6px; font-size: 11px; font-weight: bold; cursor: pointer; font-family: 'Google Sans', sans-serif; transition: background-color 0.2s;">
+              ${hasVerified ? 'Verified' : 'Verify Issue'}
             </button>
           </div>
         </div>

--- a/accore-frontend/src/app/services/hazard-report.ts
+++ b/accore-frontend/src/app/services/hazard-report.ts
@@ -9,7 +9,7 @@ import {
 } from '../shared/models/hazard-report';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class HazardReportService {
   private apiUrl = 'http://localhost:5000/api/reports';
@@ -19,26 +19,26 @@ export class HazardReportService {
   private getAuthHeaders(): HttpHeaders {
     const token = localStorage.getItem('adminToken') || localStorage.getItem('token');
     return new HttpHeaders({
-      Authorization: `Bearer ${token}`
+      Authorization: `Bearer ${token}`,
     });
   }
 
   submitReport(formData: FormData): Observable<HazardReport> {
     return this.http.post<HazardReport>(this.apiUrl, formData, {
-      headers: this.getAuthHeaders()
+      headers: this.getAuthHeaders(),
     });
   }
 
   getReports(): Observable<HazardReport[]> {
     return this.http.get<HazardReport[]>(this.apiUrl, {
-      headers: this.getAuthHeaders()
+      headers: this.getAuthHeaders(),
     });
   }
 
   // Fetches public map markers without requiring admin privileges
   getAllPublicReports(): Observable<HazardReport[]> {
     return this.http.get<HazardReport[]>(`${this.apiUrl}/public`, {
-      headers: this.getAuthHeaders()
+      headers: this.getAuthHeaders(),
     });
   }
 
@@ -87,25 +87,43 @@ export class HazardReportService {
 
   getAnalytics(): Observable<any> {
     return this.http.get<any>(`${this.apiUrl}/analytics`, {
-      headers: this.getAuthHeaders()
+      headers: this.getAuthHeaders(),
     });
   }
 
   getReportById(id: string): Observable<HazardReport> {
     return this.http.get<HazardReport>(`${this.apiUrl}/${id}`, {
-      headers: this.getAuthHeaders()
+      headers: this.getAuthHeaders(),
     });
   }
 
   updateReportStatus(id: string, status: HazardReportStatus): Observable<HazardReport> {
-    return this.http.put<HazardReport>(`${this.apiUrl}/${id}/status`, { status }, {
-      headers: this.getAuthHeaders()
-    });
+    return this.http.put<HazardReport>(
+      `${this.apiUrl}/${id}/status`,
+      { status },
+      {
+        headers: this.getAuthHeaders(),
+      },
+    );
   }
 
   archiveReport(id: string): Observable<HazardReport> {
-    return this.http.put<HazardReport>(`${this.apiUrl}/${id}/archive`, {}, {
-      headers: this.getAuthHeaders()
-    });
+    return this.http.put<HazardReport>(
+      `${this.apiUrl}/${id}/archive`,
+      {},
+      {
+        headers: this.getAuthHeaders(),
+      },
+    );
+  }
+
+  toggleVerify(id: string) {
+    return this.http.patch(
+      `${this.apiUrl}/${id}/verify`,
+      {},
+      {
+        headers: this.getAuthHeaders(),
+      },
+    );
   }
 }

--- a/accore-frontend/src/app/shared/models/hazard-report.ts
+++ b/accore-frontend/src/app/shared/models/hazard-report.ts
@@ -29,6 +29,8 @@ export interface HazardReport {
   status: HazardReportStatus;
   isArchived?: boolean;
   imageURL: string;
+  verifications: string[];
+  hasVerified?: boolean;
   statusHistory: HazardReportStatusHistoryEntry[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
This PR introduces a crowdsourced verification system that allows citizens to verify reported hazards via the dashboard map. This helps city admins prioritize issues based on community feedback and reduces the likelihood of duplicate or fraudulent reports.


Backend:

- Updated HazardReport model to include a verifications array of Citizen ObjectIds.
- Implemented toggleVerify controller logic to handle adding/removing verifications while preventing duplicates.
- Updated getPublicReports to include verification data in the public map feed.
- Added a secure PATCH route for verification protected by JWT authentication.

Frontend:

- Updated shared HazardReport models to support verification counts.
- Refactored the Citizen Dashboard to handle Leaflet popup events for the new "Verify Issue" action.
- Improved UI state management for the verify button (color changes and loading states).
- Moved dashboard-specific Leaflet styles to dashboard.css for better maintainability.