### PR TITLE
feat: implement pagination refactor, analytics caching, and strict zod

### DIFF
--- a/accore-backend/package-lock.json
+++ b/accore-backend/package-lock.json
@@ -20,7 +20,9 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.19.1",
         "multer": "^2.0.2",
-        "streamifier": "^0.1.1"
+        "node-cache": "^5.1.2",
+        "streamifier": "^0.1.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -28,6 +30,7 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^2.0.0",
         "@types/node": "^24.5.2",
+        "@types/node-cache": "^4.1.3",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2"
       }
@@ -2685,6 +2688,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/node-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node-cache/-/node-cache-4.1.3.tgz",
+      "integrity": "sha512-3hsqnv3H1zkOhjygJaJUYmgz5+FcPO3vejBX7cE9/cnuINOJYrzkfOnUCvpwGe9kMZANIHJA7J5pOdeyv52OEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -2954,6 +2967,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cloudinary": {
@@ -4201,6 +4223,18 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -5157,6 +5191,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/accore-backend/package.json
+++ b/accore-backend/package.json
@@ -22,7 +22,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.19.1",
     "multer": "^2.0.2",
-    "streamifier": "^0.1.1"
+    "node-cache": "^5.1.2",
+    "streamifier": "^0.1.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
@@ -30,6 +32,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.5.2",
+    "@types/node-cache": "^4.1.3",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2"
   }

--- a/accore-backend/src/controllers/hazard-report.controller.ts
+++ b/accore-backend/src/controllers/hazard-report.controller.ts
@@ -5,6 +5,11 @@ import Admin from "../models/admin.model";
 import { v2 as cloudinary } from "cloudinary";
 import { PRIORITY_COMMERCIAL_ZONES } from "../utils/constants";
 import { findDownstreamRisks } from "../utils/geo.utils";
+import NodeCache from "node-cache";
+
+// Initialize cache with a 10-minute (600 seconds) Time-To-Live
+const analyticsCache = new NodeCache({ stdTTL: 600 });
+const ANALYTICS_CACHE_KEY = "dashboard_analytics";
 
 interface AuthRequest extends Request {
   user?: {
@@ -12,19 +17,6 @@ interface AuthRequest extends Request {
     role: string;
   };
 }
-
-const SEVERITY_WEIGHT: Record<string, number> = {
-  Low: 1,
-  Medium: 2,
-  Critical: 3,
-};
-
-const STATUS_WEIGHT: Record<string, number> = {
-  Reported: 1,
-  "Under Review": 2,
-  "In Progress": 3,
-  Resolved: 4,
-};
 
 const ACTIVE_PUBLIC_STATUSES = [
   "Reported",
@@ -72,6 +64,7 @@ const buildAdminMatch = (query: Request["query"]) => {
   if (category && category !== "All") filters.category = category;
   if (severity && severity !== "All") filters.severity = severity;
   if (status && status !== "All") filters.status = status;
+
   if (search) {
     const searchRegex = new RegExp(
       search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
@@ -95,12 +88,15 @@ const buildAdminMatch = (query: Request["query"]) => {
   return filters;
 };
 
-const buildAdminSort = (sortColumn: string | null, sortDirection: 1 | -1) => {
+const buildAdminSort = (
+  sortColumn: string | null,
+  sortDirection: 1 | -1,
+): Record<string, 1 | -1> => {
   switch (sortColumn) {
     case "severity":
-      return { severityWeight: sortDirection, createdAt: -1 as const };
+      return { severity: sortDirection, createdAt: -1 };
     case "status":
-      return { statusWeight: sortDirection, createdAt: -1 as const };
+      return { status: sortDirection, createdAt: -1 };
     case "createdAt":
     default:
       return { createdAt: sortDirection };
@@ -111,8 +107,6 @@ export const createReport = async (
   req: AuthRequest,
   res: Response,
 ): Promise<void> => {
-  console.log("1. Controller reached successfully. Processing image...");
-
   try {
     const citizenId = req.user?.id;
 
@@ -122,7 +116,6 @@ export const createReport = async (
     }
 
     if (!req.file) {
-      console.log("Error: No image file received.");
       res.status(400).json({ message: "Image file is required." });
       return;
     }
@@ -130,12 +123,10 @@ export const createReport = async (
     const b64 = Buffer.from(req.file.buffer).toString("base64");
     const dataURI = "data:" + req.file.mimetype + ";base64," + b64;
 
-    console.log("2. Uploading image to Cloudinary...");
     const uploadResponse = await cloudinary.uploader.upload(dataURI, {
       folder: "accore_hazards",
     });
 
-    console.log("3. Image uploaded. Saving data to MongoDB...");
     const {
       title,
       description,
@@ -181,10 +172,11 @@ export const createReport = async (
     });
 
     const savedReport = await newReport.save();
-    console.log("4. Success! Hazard report saved.");
+
+    analyticsCache.del(ANALYTICS_CACHE_KEY);
+
     res.status(201).json(savedReport);
   } catch (error: any) {
-    console.error("CRITICAL ERROR SAVING REPORT:", error);
     res.status(500).json({
       message: "Failed to create hazard report",
       error: error.message,
@@ -217,56 +209,19 @@ export const getReports = async (
         const sortColumn = normalizeQueryValue(req.query.sortColumn);
         const sortDirection =
           normalizeQueryValue(req.query.sortDirection) === "asc" ? 1 : -1;
-        const pipeline: any[] = [];
+        const sortCriteria = buildAdminSort(sortColumn, sortDirection);
         const archiveFilter = filters.isArchived;
 
-        if (Object.keys(filters).length) {
-          pipeline.push({ $match: filters });
-        }
-
-        pipeline.push({
-          $addFields: {
-            severityWeight: {
-              $switch: {
-                branches: Object.entries(SEVERITY_WEIGHT).map(
-                  ([label, weight]) => ({
-                    case: { $eq: ["$severity", label] },
-                    then: weight,
-                  }),
-                ),
-                default: 0,
-              },
-            },
-            statusWeight: {
-              $switch: {
-                branches: Object.entries(STATUS_WEIGHT).map(
-                  ([label, weight]) => ({
-                    case: { $eq: ["$status", label] },
-                    then: weight,
-                  }),
-                ),
-                default: 0,
-              },
-            },
-          },
-        });
-
-        pipeline.push({ $sort: buildAdminSort(sortColumn, sortDirection) });
-        pipeline.push({
-          $facet: {
-            reports: [{ $skip: skip }, { $limit: limit }],
-            totalCount: [{ $count: "count" }],
-          },
-        });
-
-        const [aggregateResult, barangays, categories] = await Promise.all([
-          HazardReport.aggregate(pipeline),
+        // Run queries in parallel for better performance
+        const [reports, total, barangays, categories] = await Promise.all([
+          HazardReport.find(filters)
+            .sort(sortCriteria as any)
+            .skip(skip)
+            .limit(limit),
+          HazardReport.countDocuments(filters),
           HazardReport.distinct("barangay", { isArchived: archiveFilter }),
           HazardReport.distinct("category", { isArchived: archiveFilter }),
         ]);
-        const [result] = aggregateResult;
-        const reports = result?.reports ?? [];
-        const total = result?.totalCount?.[0]?.count ?? 0;
 
         res.status(200).json({
           reports,
@@ -417,6 +372,7 @@ export const getReportById = async (req: AuthRequest, res: Response) => {
     res.status(500).json({ message: "Server error retrieving the report" });
   }
 };
+
 export const updateReportStatus = async (
   req: AuthRequest,
   res: Response,
@@ -431,7 +387,6 @@ export const updateReportStatus = async (
       return;
     }
 
-    // Updated validation array
     const validStatuses = [
       "Reported",
       "Under Review",
@@ -466,6 +421,8 @@ export const updateReportStatus = async (
 
     const updatedReport = await report.save();
 
+    analyticsCache.del(ANALYTICS_CACHE_KEY);
+
     res.status(200).json(updatedReport);
   } catch (error: any) {
     res.status(500).json({
@@ -480,6 +437,12 @@ export const getAnalytics = async (
   res: Response,
 ): Promise<void> => {
   try {
+    const cachedData = analyticsCache.get(ANALYTICS_CACHE_KEY);
+    if (cachedData) {
+      res.status(200).json(cachedData);
+      return;
+    }
+
     const analyticsData = await HazardReport.aggregate([
       {
         $match: {
@@ -508,7 +471,6 @@ export const getAnalytics = async (
               },
             },
           ],
-          // Inside getAnalytics function, update the activeHotspots array:
           activeHotspots: [
             {
               $match: {
@@ -546,6 +508,8 @@ export const getAnalytics = async (
       recentActivity: data?.recentActivity || [],
       activeHotspots: data?.activeHotspots || [],
     };
+
+    analyticsCache.set(ANALYTICS_CACHE_KEY, result);
 
     res.status(200).json(result);
   } catch (error: any) {
@@ -585,7 +549,6 @@ export const toggleVerify = async (
 ): Promise<void> => {
   try {
     const reportId = req.params.id;
-    // Check for both id and _id depending on how your JWT payload is structured
     const userId = req.user?.id || req.user?._id;
 
     if (!userId) {
@@ -602,26 +565,21 @@ export const toggleVerify = async (
       return;
     }
 
-    // Safely initialize the array if it doesn't exist for older reports
     if (!report.verifications) {
       report.verifications = [];
     }
 
-    // Clean out any null/undefined values that might have sneaked into the DB
     report.verifications = report.verifications.filter((id) => id != null);
 
-    // Safely check if the user has already verified
     const hasVerified = report.verifications.some(
       (id) => id && id.toString() === userId.toString(),
     );
 
     if (hasVerified) {
-      // User already verified, so we remove their ID (un-verify)
       report.verifications = report.verifications.filter(
         (id) => id && id.toString() !== userId.toString(),
       );
     } else {
-      // User has not verified, so we add their ID
       report.verifications.push(userId as any);
     }
 
@@ -629,7 +587,6 @@ export const toggleVerify = async (
 
     res.status(200).json(report);
   } catch (error: any) {
-    console.error("Error toggling verification:", error);
     res
       .status(500)
       .json({ message: "Internal server error", error: error.message });
@@ -638,21 +595,21 @@ export const toggleVerify = async (
 
 export const getDownstreamGroupings = async (
   req: AuthRequest,
-  res: Response
+  res: Response,
 ): Promise<void> => {
   try {
     const activeWaterReports = await HazardReport.find({
       category: { $in: ["Flooding", "Clogged Drain"] },
       status: { $in: ["Reported", "Under Review", "In Progress"] },
       isArchived: false,
-    }).sort({ elevation: -1 }); 
+    }).sort({ elevation: -1 });
 
     const groupedReports: Record<string, any[]> = {};
     const processedIds = new Set<string>();
 
     activeWaterReports.forEach((sourceReport) => {
       const sourceId = sourceReport._id.toString();
-      
+
       if (processedIds.has(sourceId)) return;
 
       const downstreamGroup = [sourceReport];
@@ -660,14 +617,14 @@ export const getDownstreamGroupings = async (
 
       activeWaterReports.forEach((targetReport) => {
         const targetId = targetReport._id.toString();
-        
+
         if (sourceId === targetId || processedIds.has(targetId)) return;
 
         const isRisk = findDownstreamRisks(
           sourceReport.location.coordinates,
           sourceReport.elevation,
           targetReport.location.coordinates,
-          targetReport.elevation
+          targetReport.elevation,
         );
 
         if (isRisk) {

--- a/accore-backend/src/middlewares/validation.middleware.ts
+++ b/accore-backend/src/middlewares/validation.middleware.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction } from "express";
+import { z, ZodError } from "zod";
+
+export const validate =
+  (schema: z.ZodSchema) =>
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      await schema.parseAsync({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+      });
+      
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({
+          message: "Input validation failed",
+          errors: error.issues.map((issue) => ({
+            field: issue.path.join("."),
+            message: issue.message,
+          })),
+        });
+        return;
+      }
+      
+      res.status(500).json({ message: "Internal server error during validation" });
+    }
+  };

--- a/accore-backend/src/routes/hazard-report.routes.ts
+++ b/accore-backend/src/routes/hazard-report.routes.ts
@@ -8,25 +8,46 @@ import {
   getAnalytics,
   getPublicReports,
   toggleVerify,
-  getDownstreamGroupings
+  getDownstreamGroupings,
 } from "../controllers/hazard-report.controller";
 import { upload } from "../middlewares/upload.middleware";
 import { verifyToken, verifyAdmin } from "../middlewares/auth.middleware";
 import { reportLimiter } from "../middlewares/rate-limit.middleware";
+import { validate } from "../middlewares/validation.middleware";
+import { createReportSchema, updateStatusSchema } from "../validations/hazard-report.validation";
 
 const router = Router();
 
-// Static routes must come before dynamic /:id routes
 router.get("/analytics", verifyToken, verifyAdmin, getAnalytics);
-router.get("/downstream-risks", verifyToken, verifyAdmin, getDownstreamGroupings);
+router.get(
+  "/downstream-risks",
+  verifyToken,
+  verifyAdmin,
+  getDownstreamGroupings,
+);
 router.get("/public", verifyToken, getPublicReports);
 router.get("/", verifyToken, getReports);
 
-// Dynamic routes
-router.post("/", verifyToken, reportLimiter, upload.single("image"), createReport);
+router.post(
+  "/",
+  verifyToken,
+  reportLimiter,
+  upload.single("image"),
+  validate(createReportSchema),
+  createReport,
+);
+
 router.get("/:id", verifyToken, getReportById);
 router.patch("/:id/verify", verifyToken, toggleVerify);
-router.put("/:id/status", verifyToken, verifyAdmin, updateReportStatus);
+
+router.put(
+  "/:id/status", 
+  verifyToken, 
+  verifyAdmin, 
+  validate(updateStatusSchema), 
+  updateReportStatus
+);
+
 router.put("/:id/archive", verifyToken, verifyAdmin, archiveReport);
 
 export default router;

--- a/accore-backend/src/validations/hazard-report.validation.ts
+++ b/accore-backend/src/validations/hazard-report.validation.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { ANGELES_CITY_BARANGAYS } from "../utils/constants";
+
+export const createReportSchema = z.object({
+  body: z.object({
+    title: z.string().min(3, "Title is too short").max(100, "Title is too long"),
+    description: z.string().min(10, "Please provide more details").max(1000, "Description exceeds the 1000 character limit"),
+    category: z.enum(["Pothole", "Clogged Drain", "Fallen Tree", "Streetlight Out", "Flooding"], {
+      errorMap: () => ({ message: "Invalid category" }),
+    }),
+    severity: z.enum(["Low", "Medium", "Critical"], {
+      errorMap: () => ({ message: "Invalid severity level" }),
+    }),
+    barangay: z.string().refine((val) => ANGELES_CITY_BARANGAYS.includes(val as any), {
+      message: "Please select a valid Angeles City barangay",
+    }),
+    latitude: z.string().refine(
+      (val) => {
+        const num = parseFloat(val);
+        return !isNaN(num) && num >= 15.10 && num <= 15.25;
+      },
+      { message: "Location is outside Angeles City bounds" }
+    ),
+    longitude: z.string().refine(
+      (val) => {
+        const num = parseFloat(val);
+        return !isNaN(num) && num >= 120.50 && num <= 120.65;
+      },
+      { message: "Location is outside Angeles City bounds" }
+    ),
+  }),
+});
+
+export const updateStatusSchema = z.object({
+  body: z.object({
+    status: z.enum(["Reported", "Under Review", "In Progress", "Resolved"], {
+      errorMap: () => ({ message: "Invalid status update" }),
+    }),
+  }),
+});

--- a/accore-frontend/src/app/citizen/report/report.html
+++ b/accore-frontend/src/app/citizen/report/report.html
@@ -2,34 +2,54 @@
   <app-citizen-header class="sticky top-0 z-50 block w-full"></app-citizen-header>
 
   <div class="p-4 md:p-8">
-    <div class="max-w-3xl mx-auto bg-white shadow-2xl md:rounded-2xl overflow-hidden border border-slate-200">
+    <div
+      class="max-w-3xl mx-auto bg-white shadow-2xl md:rounded-2xl overflow-hidden border border-slate-200"
+    >
       <div class="relative h-72 md:h-96 w-full bg-slate-200">
         <div id="map" class="w-full h-full z-10"></div>
 
         <div class="absolute top-4 left-4 z-20">
           <span
-            class="bg-red-800 text-white text-[10px] px-3 py-1 rounded-full font-bold uppercase tracking-wider shadow-lg border border-red-900/20">
+            class="bg-red-800 text-white text-[10px] px-3 py-1 rounded-full font-bold uppercase tracking-wider shadow-lg border border-red-900/20"
+          >
             Angeles City Hazard Map
           </span>
         </div>
 
         <div class="absolute top-4 right-4 z-20">
-          <a routerLink="/dashboard" hlmBtn variant="secondary" size="icon"
-            class="rounded-full shadow-md bg-white/90 backdrop-blur hover:bg-white border border-slate-200">
+          <a
+            routerLink="/dashboard"
+            hlmBtn
+            variant="secondary"
+            size="icon"
+            class="rounded-full shadow-md bg-white/90 backdrop-blur hover:bg-white border border-slate-200"
+          >
             <lucide-icon name="x" class="w-4 h-4 text-slate-600"></lucide-icon>
           </a>
         </div>
 
         <div class="absolute bottom-6 left-1/2 -translate-x-1/2 z-20 w-auto">
-          <button type="button" (click)="locateUserManual()" hlmBtn variant="secondary"
+          <button
+            type="button"
+            (click)="locateUserManual()"
+            hlmBtn
+            variant="secondary"
             class="rounded-full shadow-2xl bg-white/95 backdrop-blur hover:bg-white px-6 h-11 border border-slate-200 flex items-center gap-2 group transition-all active:scale-95"
-            [disabled]="isLocating()">
+            [disabled]="isLocating()"
+          >
             @if (isLocating()) {
-            <hlm-spinner class="w-4 h-4 text-red-800"></hlm-spinner>
-            <span class="text-xs font-bold uppercase tracking-tight text-slate-700">Detecting...</span>
+              <hlm-spinner class="w-4 h-4 text-red-800"></hlm-spinner>
+              <span class="text-xs font-bold uppercase tracking-tight text-slate-700"
+                >Detecting...</span
+              >
             } @else {
-            <lucide-icon name="navigation" class="w-4 h-4 text-red-800 group-hover:animate-pulse"></lucide-icon>
-            <span class="text-xs font-bold uppercase tracking-tight text-slate-700">Locate Me</span>
+              <lucide-icon
+                name="navigation"
+                class="w-4 h-4 text-red-800 group-hover:animate-pulse"
+              ></lucide-icon>
+              <span class="text-xs font-bold uppercase tracking-tight text-slate-700"
+                >Locate Me</span
+              >
             }
           </button>
         </div>
@@ -47,14 +67,14 @@
               </p>
               <h3 class="text-lg font-bold text-slate-900 leading-tight">
                 {{
-                reportForm.get('barangay')?.value ||
-                (isLocating() ? 'Searching...' : 'Move pin on map')
+                  reportForm.get('barangay')?.value ||
+                    (isLocating() ? 'Searching...' : 'Move pin on map')
                 }}
               </h3>
               <p class="text-xs text-slate-500">Hazard location is automatically detected.</p>
             </div>
             @if (isLocating()) {
-            <hlm-spinner class="w-5 h-5 text-red-700"></hlm-spinner>
+              <hlm-spinner class="w-5 h-5 text-red-700"></hlm-spinner>
             }
           </div>
 
@@ -93,76 +113,134 @@
 
             <div class="space-y-2">
               <label hlmLabel>Report Title</label>
-              <input hlmInput formControlName="title" placeholder="Briefly name the issue" class="w-full h-12" />
+              <input
+                hlmInput
+                formControlName="title"
+                placeholder="Briefly name the issue"
+                class="w-full h-12"
+              />
+              @if (reportForm.get('title')?.invalid && reportForm.get('title')?.touched) {
+                <div class="text-red-500 text-xs mt-1 font-medium">
+                  @if (reportForm.get('title')?.errors?.['minlength']) {
+                    <span>Title must be at least 3 characters.</span>
+                  }
+                  @if (reportForm.get('title')?.errors?.['maxlength']) {
+                    <span>Title cannot exceed 100 characters.</span>
+                  }
+                </div>
+              }
             </div>
 
             <div class="space-y-2">
               <label hlmLabel>Description</label>
-              <textarea hlmTextarea formControlName="description"
-                placeholder="Describe landmarks or specific details..." rows="3" class="w-full"></textarea>
+              <textarea
+                hlmTextarea
+                formControlName="description"
+                placeholder="Describe landmarks or specific details..."
+                rows="3"
+                class="w-full"
+              ></textarea>
+              @if (
+                reportForm.get('description')?.invalid && reportForm.get('description')?.touched
+              ) {
+                <div class="text-red-500 text-xs mt-1 font-medium">
+                  @if (reportForm.get('description')?.errors?.['minlength']) {
+                    <span>Please provide more details (at least 10 characters).</span>
+                  }
+                  @if (reportForm.get('description')?.errors?.['maxlength']) {
+                    <span>Description cannot exceed 1000 characters.</span>
+                  }
+                </div>
+              }
             </div>
 
             <div class="space-y-3">
               <label hlmLabel>Proof of Hazard</label>
               @if (!showUpload() && !imagePreview()) {
-              <button hlmBtn variant="outline" type="button"
-                class="w-full flex items-center justify-center gap-3 py-10 border-2 border-dashed border-slate-300 rounded-xl text-slate-600 hover:bg-slate-50 transition-all"
-                (click)="showUpload.set(true)">
-                <lucide-icon name="camera" class="w-6 h-6"></lucide-icon>
-                <span class="font-semibold">Add Hazard Photo</span>
-              </button>
+                <button
+                  hlmBtn
+                  variant="outline"
+                  type="button"
+                  class="w-full flex items-center justify-center gap-3 py-10 border-2 border-dashed border-slate-300 rounded-xl text-slate-600 hover:bg-slate-50 transition-all"
+                  (click)="showUpload.set(true)"
+                >
+                  <lucide-icon name="camera" class="w-6 h-6"></lucide-icon>
+                  <span class="font-semibold">Add Hazard Photo</span>
+                </button>
               } @else {
-              <div class="relative">
-                @if (imagePreview()) {
-                <div class="group relative w-full h-56 rounded-xl overflow-hidden shadow-md">
-                  <img [src]="imagePreview()" class="w-full h-full object-cover" />
-                  <div
-                    class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                    <button type="button" (click)="removeImage()"
-                      class="bg-white text-red-600 p-3 rounded-full shadow-xl">
-                      <lucide-icon name="x" class="w-6 h-6"></lucide-icon>
-                    </button>
-                  </div>
+                <div class="relative">
+                  @if (imagePreview()) {
+                    <div class="group relative w-full h-56 rounded-xl overflow-hidden shadow-md">
+                      <img [src]="imagePreview()" class="w-full h-full object-cover" />
+                      <div
+                        class="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                      >
+                        <button
+                          type="button"
+                          (click)="removeImage()"
+                          class="bg-white text-red-600 p-3 rounded-full shadow-xl"
+                        >
+                          <lucide-icon name="x" class="w-6 h-6"></lucide-icon>
+                        </button>
+                      </div>
+                    </div>
+                  } @else {
+                    <label
+                      class="flex flex-col items-center justify-center w-full h-56 border-2 border-dashed rounded-xl cursor-pointer bg-slate-50 border-slate-300 hover:border-red-400 hover:bg-red-50/30 transition-all"
+                    >
+                      <lucide-icon
+                        name="upload-cloud"
+                        class="w-10 h-10 mb-2 text-slate-400"
+                      ></lucide-icon>
+                      <p class="text-sm font-medium text-slate-600">Click to upload photo</p>
+                      <input
+                        type="file"
+                        class="hidden"
+                        (change)="onFileSelected($event)"
+                        accept="image/*"
+                      />
+                    </label>
+                  }
                 </div>
-                } @else {
-                <label
-                  class="flex flex-col items-center justify-center w-full h-56 border-2 border-dashed rounded-xl cursor-pointer bg-slate-50 border-slate-300 hover:border-red-400 hover:bg-red-50/30 transition-all">
-                  <lucide-icon name="upload-cloud" class="w-10 h-10 mb-2 text-slate-400"></lucide-icon>
-                  <p class="text-sm font-medium text-slate-600">Click to upload photo</p>
-                  <input type="file" class="hidden" (change)="onFileSelected($event)" accept="image/*" />
-                </label>
-                }
-              </div>
               }
             </div>
           </div>
 
           <div class="pt-6 border-t border-slate-100">
-            <button hlmBtn type="submit"
+            <button
+              hlmBtn
+              type="submit"
               class="w-full h-14 bg-red-800 hover:bg-red-900 text-white rounded-xl text-lg font-bold shadow-xl disabled:opacity-50"
               [disabled]="
                 reportForm.invalid ||
                 !selectedFile ||
                 isSubmitting() ||
                 !reportForm.get('barangay')?.value
-              ">
+              "
+            >
               @if (isSubmitting()) {
-              <hlm-spinner class="mr-2 w-5 h-5"></hlm-spinner>
-              <span>Submitting Report...</span>
+                <hlm-spinner class="mr-2 w-5 h-5"></hlm-spinner>
+                <span>Submitting Report...</span>
               } @else {
-              <span>Submit Hazard Report</span>
+                <span>Submit Hazard Report</span>
               }
             </button>
 
             @if (statusMessage()) {
-            <div [class]="
+              <div
+                [class]="
                   isError()
                     ? 'text-red-600 bg-red-50 border-red-100'
                     : 'text-green-700 bg-green-50 border-green-100'
-                " class="mt-4 p-4 rounded-xl border text-sm font-semibold flex items-center gap-2">
-              <lucide-icon [name]="isError() ? 'alert-triangle' : 'check-circle-2'" class="w-4 h-4"></lucide-icon>
-              {{ statusMessage() }}
-            </div>
+                "
+                class="mt-4 p-4 rounded-xl border text-sm font-semibold flex items-center gap-2"
+              >
+                <lucide-icon
+                  [name]="isError() ? 'alert-triangle' : 'check-circle-2'"
+                  class="w-4 h-4"
+                ></lucide-icon>
+                {{ statusMessage() }}
+              </div>
             }
           </div>
         </form>

--- a/accore-frontend/src/app/citizen/report/report.ts
+++ b/accore-frontend/src/app/citizen/report/report.ts
@@ -1,4 +1,12 @@
-import { Component, inject, OnInit, OnDestroy, signal, ChangeDetectorRef, NgZone } from '@angular/core';
+import {
+  Component,
+  inject,
+  OnInit,
+  OnDestroy,
+  signal,
+  ChangeDetectorRef,
+  NgZone,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -23,9 +31,19 @@ import * as L from 'leaflet';
   selector: 'app-report',
   standalone: true,
   imports: [
-    CommonModule, ReactiveFormsModule, RouterModule, LucideAngularModule,
-    HlmButtonImports, HlmInputImports, HlmLabelImports,
-    BrnSelectImports, HlmSelectImports, HlmTextareaImports, HlmSpinnerImports, CitizenHeaderComponent, CitizenFooterComponent
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    LucideAngularModule,
+    HlmButtonImports,
+    HlmInputImports,
+    HlmLabelImports,
+    BrnSelectImports,
+    HlmSelectImports,
+    HlmTextareaImports,
+    HlmSpinnerImports,
+    CitizenHeaderComponent,
+    CitizenFooterComponent,
   ],
   templateUrl: './report.html',
 })
@@ -49,11 +67,11 @@ export class Report implements OnInit, OnDestroy {
   selectedFile: File | null = null;
 
   reportForm = this.fb.group({
-    title: ['', [Validators.required, Validators.maxLength(100)]],
+    title: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(100)]],
     category: ['', Validators.required],
     severity: ['', Validators.required],
     barangay: [{ value: '', disabled: true }, Validators.required],
-    description: ['', Validators.required],
+    description: ['', [Validators.required, Validators.minLength(10), Validators.maxLength(1000)]],
     latitude: [APP_CONFIG.map.defaultLat],
     longitude: [APP_CONFIG.map.defaultLng],
   });
@@ -71,14 +89,14 @@ export class Report implements OnInit, OnDestroy {
 
   private initMap() {
     const start: [number, number] = [APP_CONFIG.map.defaultLat, APP_CONFIG.map.defaultLng];
-    
-    this.map = L.map('map', { 
+
+    this.map = L.map('map', {
       scrollWheelZoom: APP_CONFIG.map.scrollWheel,
-      zoomControl: false 
+      zoomControl: false,
     }).setView(start, APP_CONFIG.map.defaultZoom);
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution: '© OpenStreetMap'
+      attribution: '© OpenStreetMap',
     }).addTo(this.map);
 
     const teardropPin = L.divIcon({
@@ -101,19 +119,18 @@ export class Report implements OnInit, OnDestroy {
     this.marker.on('dragend', () => {
       this.ngZone.run(() => this.handlePinMovement());
     });
-    
+
     this.map.on('click', (e) => {
       this.marker?.setLatLng(e.latlng);
       this.ngZone.run(() => this.handlePinMovement());
     });
 
-    // Auto-locate on load
     this.locateUserManual();
   }
 
   locateUserManual() {
-    if (this.isLocating()) return; // Prevent spamming
-    
+    if (this.isLocating()) return;
+
     if (!('geolocation' in navigator)) {
       this.statusMessage.set('GPS is not supported by your browser.');
       this.isError.set(true);
@@ -121,41 +138,39 @@ export class Report implements OnInit, OnDestroy {
     }
 
     this.isLocating.set(true);
-    this.statusMessage.set(''); // Clear any previous errors
+    this.statusMessage.set('');
 
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         const coords: [number, number] = [pos.coords.latitude, pos.coords.longitude];
-        
-        // Visual feedback: Fly to location
+
         this.map?.flyTo(coords, APP_CONFIG.map.activeZoom, {
           animate: true,
-          duration: 1.5
+          duration: 1.5,
         });
 
         this.marker?.setLatLng(coords);
-        
-        // Trigger the backend call for Barangay detection
+
         this.ngZone.run(() => this.handlePinMovement());
       },
       (err) => {
         this.isLocating.set(false);
         this.isError.set(true);
-        
+
         const errorMessages: Record<number, string> = {
           1: 'Permission denied. Please allow location access.',
           2: 'Position unavailable. Check your signal.',
-          3: 'GPS request timed out.'
+          3: 'GPS request timed out.',
         };
-        
+
         this.statusMessage.set(errorMessages[err.code] || 'Could not find your location.');
         this.cdr.detectChanges();
       },
-      { 
-        enableHighAccuracy: true, 
-        timeout: 8000, 
-        maximumAge: 0 
-      }
+      {
+        enableHighAccuracy: true,
+        timeout: 8000,
+        maximumAge: 0,
+      },
     );
   }
 
@@ -165,7 +180,7 @@ export class Report implements OnInit, OnDestroy {
 
     this.reportForm.patchValue({ latitude: pos.lat, longitude: pos.lng });
     this.isLocating.set(true);
-    this.cdr.detectChanges(); 
+    this.cdr.detectChanges();
 
     this.barangayService.getNearestBarangay(pos.lng, pos.lat).subscribe({
       next: (res) => {
@@ -182,12 +197,12 @@ export class Report implements OnInit, OnDestroy {
         this.statusMessage.set('Location not recognized. Pin within city boundaries.');
         this.isLocating.set(false);
         this.cdr.detectChanges();
-      }
+      },
     });
   }
 
   private setupAutoSuggest() {
-    this.reportForm.get('category')?.valueChanges.subscribe(cat => {
+    this.reportForm.get('category')?.valueChanges.subscribe((cat) => {
       if (cat && APP_CONFIG.severityMapping[cat]) {
         this.reportForm.patchValue({ severity: APP_CONFIG.severityMapping[cat] });
       }
@@ -197,7 +212,7 @@ export class Report implements OnInit, OnDestroy {
   async onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     if (!input.files?.length) return;
-    
+
     const file = input.files.item(0);
     if (!file) return;
 
@@ -205,7 +220,7 @@ export class Report implements OnInit, OnDestroy {
     try {
       const compressed = await imageCompression(file, APP_CONFIG.image);
       this.selectedFile = new File([compressed], file.name, { type: file.type });
-      
+
       const reader = new FileReader();
       reader.onload = () => this.imagePreview.set(reader.result as string);
       reader.readAsDataURL(this.selectedFile);
@@ -242,12 +257,15 @@ export class Report implements OnInit, OnDestroy {
         this.isSubmitting.set(false);
         this.statusMessage.set('Submission failed. Check your network or image size.');
         this.isError.set(true);
-      }
+      },
     });
   }
 
   private reset() {
-    this.reportForm.reset({ latitude: APP_CONFIG.map.defaultLat, longitude: APP_CONFIG.map.defaultLng });
+    this.reportForm.reset({
+      latitude: APP_CONFIG.map.defaultLat,
+      longitude: APP_CONFIG.map.defaultLng,
+    });
     this.removeImage();
     this.marker?.setLatLng([APP_CONFIG.map.defaultLat, APP_CONFIG.map.defaultLng]);
   }


### PR DESCRIPTION
## Overview
This PR implements performance optimizations and security enhancements for the hazard reporting backend and the citizen reporting form.

## Changes
- **Pagination Refactor**: Replaced the memory-heavy `$facet` operator in `getReports` with standard MongoDB `find()`, `skip()`, and `limit()` methods.
- **Analytics Caching**: Integrated `node-cache` to store dashboard analytics in memory for 10 minutes (600s TTL). Added automatic cache invalidation when reports are created or updated.
- **Strict Input Validation**: Implemented `Zod` schemas for hazard report creation and status updates. This includes strict coordinate range checks to ensure reports stay within Angeles City boundaries.
- **Frontend UX Improvements**: Updated the citizen hazard report form with Reactive Form Validators and real-time error messages to match the new backend rules.

## Related Issues
- Fixes #111
- Fixes #43